### PR TITLE
Only use option.WithScopes if the input URI contains scopes

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -36,7 +36,10 @@ func (b bigQueryDriver) Open(uri string) (driver.Conn, error) {
 
 	ctx := context.Background()
 
-	opts := []option.ClientOption{option.WithScopes(config.scopes...)}
+	opts := []option.ClientOption{}
+	if len(config.scopes) > 0 {
+		opts = append(opts, option.WithScopes(config.scopes...))
+	}
 	if config.endpoint != "" {
 		opts = append(opts, option.WithEndpoint(config.endpoint))
 	}


### PR DESCRIPTION
When the bigquery URI given to `sql.Open` does not specify any OAuth 2 scopes,
this driver would still include `option.WithScopes` when creating the BigQuery
client, but the requested scopes would be an empty list. This resulted in a 401 error
when the codegen check in Jenkins attempts to run SQL on BigQuery using this
driver.

It can be fixed by passing the right scope(s) like `https://www.googleapis.com/auth/bigquery`,
but it seems reasonable to fix this particular bug by only using the `WithScopes` option
if some scopes are actually given in the URI.

Tested in https://phabricator.rubrik.com/D311600 (the 401 error in sail goes away after
this change, or after setting the right scopes as mentioned above).