### PR TITLE
Convert civil time related types to time.Time

### DIFF
--- a/driver/columns.go
+++ b/driver/columns.go
@@ -53,30 +53,36 @@ type bigQueryColumn struct {
 func (column bigQueryColumn) ConvertValue(value bigquery.Value) (driver.Value, error) {
 	// Handle DATE type conversion from civil.Date to time.Time
 	if column.FieldType == bigquery.DateFieldType {
-		if civilDate, ok := value.(civil.Date); ok {
-			converted := time.Date(civilDate.Year, civilDate.Month, civilDate.Day, 0, 0, 0, 0, time.UTC)
-			return converted, nil
-		}
-	}
-
-	// Handle TIME type conversion from civil.Time to time.Time
-	if column.FieldType == bigquery.TimeFieldType {
-		if civilTime, ok := value.(civil.Time); ok {
-			// Convert civil.Time to time.Time (today's date with the specified time in UTC)
-			now := time.Now().UTC()
-			converted := time.Date(now.Year(), now.Month(), now.Day(),
-				civilTime.Hour, civilTime.Minute, civilTime.Second, civilTime.Nanosecond, time.UTC)
-			return converted, nil
+		if value != nil {
+			if civilDate, ok := value.(civil.Date); ok {
+				converted := time.Date(civilDate.Year, civilDate.Month, civilDate.Day, 0, 0, 0, 0, time.UTC)
+				return converted, nil
+			}
 		}
 	}
 
 	// Handle DATETIME type conversion from civil.DateTime to time.Time
 	if column.FieldType == bigquery.DateTimeFieldType {
-		if civilDateTime, ok := value.(civil.DateTime); ok {
-			converted := time.Date(civilDateTime.Date.Year, civilDateTime.Date.Month, civilDateTime.Date.Day,
-				civilDateTime.Time.Hour, civilDateTime.Time.Minute, civilDateTime.Time.Second,
-				civilDateTime.Time.Nanosecond, time.UTC)
-			return converted, nil
+		if value != nil {
+			if civilDateTime, ok := value.(civil.DateTime); ok {
+				converted := time.Date(civilDateTime.Date.Year, civilDateTime.Date.Month, civilDateTime.Date.Day,
+					civilDateTime.Time.Hour, civilDateTime.Time.Minute, civilDateTime.Time.Second,
+					civilDateTime.Time.Nanosecond, time.UTC)
+				return converted, nil
+			}
+		}
+	}
+
+	// Handle TIME type conversion from civil.Time to time.Time
+	if column.FieldType == bigquery.TimeFieldType {
+		if value != nil {
+			if civilTime, ok := value.(civil.Time); ok {
+				// Convert civil.Time to time.Time (today's date with the specified time in UTC)
+				now := time.Now().UTC()
+				converted := time.Date(now.Year(), now.Month(), now.Day(),
+					civilTime.Hour, civilTime.Minute, civilTime.Second, civilTime.Nanosecond, time.UTC)
+				return converted, nil
+			}
 		}
 	}
 

--- a/driver/columns.go
+++ b/driver/columns.go
@@ -3,8 +3,10 @@ package driver
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 
 	"github.com/scaledata/bigquery/adaptor"
 )
@@ -42,12 +44,41 @@ func (c bigQueryReroutedColumn) MarshalJSON() ([]byte, error) {
 }
 
 type bigQueryColumn struct {
-	Name    string
-	Schema  bigquery.Schema
-	Adaptor adaptor.SchemaColumnAdaptor
+	Name      string
+	Schema    bigquery.Schema
+	Adaptor   adaptor.SchemaColumnAdaptor
+	FieldType bigquery.FieldType // Add field type information
 }
 
 func (column bigQueryColumn) ConvertValue(value bigquery.Value) (driver.Value, error) {
+	// Handle DATE type conversion from civil.Date to time.Time
+	if column.FieldType == bigquery.DateFieldType {
+		if civilDate, ok := value.(civil.Date); ok {
+			converted := time.Date(civilDate.Year, civilDate.Month, civilDate.Day, 0, 0, 0, 0, time.UTC)
+			return converted, nil
+		}
+	}
+
+	// Handle TIME type conversion from civil.Time to time.Time
+	if column.FieldType == bigquery.TimeFieldType {
+		if civilTime, ok := value.(civil.Time); ok {
+			// Convert civil.Time to time.Time (today's date with the specified time in UTC)
+			now := time.Now().UTC()
+			converted := time.Date(now.Year(), now.Month(), now.Day(),
+				civilTime.Hour, civilTime.Minute, civilTime.Second, civilTime.Nanosecond, time.UTC)
+			return converted, nil
+		}
+	}
+
+	// Handle DATETIME type conversion from civil.DateTime to time.Time
+	if column.FieldType == bigquery.DateTimeFieldType {
+		if civilDateTime, ok := value.(civil.DateTime); ok {
+			converted := time.Date(civilDateTime.Date.Year, civilDateTime.Date.Month, civilDateTime.Date.Day,
+				civilDateTime.Time.Hour, civilDateTime.Time.Minute, civilDateTime.Time.Second,
+				civilDateTime.Time.Nanosecond, time.UTC)
+			return converted, nil
+		}
+	}
 
 	if len(column.Schema) == 0 {
 		return value, nil
@@ -86,9 +117,10 @@ func createBigQuerySchema(schema bigquery.Schema, schemaAdaptor adaptor.SchemaAd
 
 		names = append(names, name)
 		columns = append(columns, bigQueryColumn{
-			Name:    name,
-			Schema:  column.Schema,
-			Adaptor: columnAdaptor,
+			Name:      name,
+			Schema:    column.Schema,
+			Adaptor:   columnAdaptor,
+			FieldType: column.Type, // Pass the field type information
 		})
 	}
 	return &bigQueryColumns{


### PR DESCRIPTION
### Summary:
time.Time type does not implement the scan
logic for civil time related types which the
google cloud boigquery SDK and hence this
gorm driver return.

For the go structs returned from the
gorm driver to be able to bind to
time.Time in downstream applications,
this PR changes the gorm driver to return
time.Time instead of civil types.

### Test Plan
Tested reading date, time, datetime columns
(nullable and required)

Ingested:
```
Record 1:
  VarcharType: I3bMptkj
...
  DateType: 2025-07-25T01:51:12.624348Z
  TimeType: 2024-11-24T02:47:07.547482Z
  DateTimeType: 2025-03-24T01:39:57.540222Z
  TimestampType: 2025-03-29T20:28:21.474850Z
...
  DateTypeOpt: 2025-10-20T18:19:27.935931Z
  TimeTypeOpt: 2025-07-12T09:08:27.181533Z
  DateTimeTypeOpt: 2025-04-25T02:56:02.962871Z
  TimestampTypeOpt: 2025-04-07T22:20:10.706138Z


```

Read:
```
  VarcharType: I3bMptkj
...
  DateType: 2025-07-25T00:00:00.000000Z
  TimeType: 2025-11-21T02:47:07.547482Z
  DateTimeType: 2025-03-24T01:39:57.540222Z
  TimestampType: 2025-03-29T20:28:21.474850Z
...
  DateTypeOpt: 2025-10-20T00:00:00.000000Z
  TimeTypeOpt: 2025-11-21T09:08:27.181533Z
  DateTimeTypeOpt: 2025-04-25T02:56:02.962871Z
  TimestampTypeOpt: 2025-04-07T22:20:10.706138Z

```