### PR TITLE
Export BigQueryDriver type and add SourceRowIterator accessors

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-type bigQueryDriver struct {
+type BigQueryDriver struct {
 }
 
 type bigQueryConfig struct {
@@ -23,7 +23,7 @@ type bigQueryConfig struct {
 	disableAuth bool
 }
 
-func (b bigQueryDriver) Open(uri string) (driver.Conn, error) {
+func (b BigQueryDriver) Open(uri string) (driver.Conn, error) {
 
 	if uri == "scanner" {
 		return &scannerConnection{}, nil

--- a/driver/init.go
+++ b/driver/init.go
@@ -7,5 +7,5 @@ import (
 const scannerKey = "bigquery_scanner"
 
 func init() {
-	sql.Register("bigquery", &bigQueryDriver{})
+	sql.Register("bigquery", &BigQueryDriver{})
 }

--- a/driver/result.go
+++ b/driver/result.go
@@ -16,3 +16,9 @@ func (result *bigQueryResult) LastInsertId() (int64, error) {
 func (result *bigQueryResult) RowsAffected() (int64, error) {
 	return int64(result.rowIterator.TotalRows), nil
 }
+
+// SourceRowIterator returns the underlying
+// BigQuery RowIterator.
+func (result *bigQueryResult) SourceRowIterator() *bigquery.RowIterator {
+	return result.rowIterator
+}

--- a/driver/rows.go
+++ b/driver/rows.go
@@ -4,6 +4,8 @@ import (
 	"database/sql/driver"
 	"io"
 
+	"cloud.google.com/go/bigquery"
+
 	"github.com/scaledata/bigquery/adaptor"
 	"google.golang.org/api/iterator"
 )
@@ -27,6 +29,18 @@ func (rows *bigQueryRows) Columns() []string {
 
 func (rows *bigQueryRows) Close() error {
 	return nil
+}
+
+// SourceRowIterator returns the underlying BigQuery
+// RowIterator if the source is backed by one.
+// Returns nil otherwise.
+func (rows *bigQueryRows) SourceRowIterator() *bigquery.RowIterator {
+	src, ok :=
+		rows.source.(*bigQueryRowIteratorSource)
+	if !ok {
+		return nil
+	}
+	return src.iterator
 }
 
 func (rows *bigQueryRows) Next(dest []driver.Value) error {


### PR DESCRIPTION
## Summary
- Export `BigQueryDriver` type (renamed from unexported `bigQueryDriver`) to allow external packages to reference it
- Add `SourceRowIterator()` accessor on `bigQueryResult` to expose the underlying `*bigquery.RowIterator`
- Add `SourceRowIterator()` accessor on `bigQueryRows` to expose the underlying `*bigquery.RowIterator` when the source is backed by one

