### PR TITLE
Add credentials_file DSN parameter support

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -15,12 +15,13 @@ type BigQueryDriver struct {
 }
 
 type bigQueryConfig struct {
-	projectID   string
-	location    string
-	dataSet     string
-	scopes      []string
-	endpoint    string
-	disableAuth bool
+	projectID       string
+	location        string
+	dataSet         string
+	scopes          []string
+	endpoint        string
+	disableAuth     bool
+	credentialsFile string
 }
 
 func (b BigQueryDriver) Open(uri string) (driver.Conn, error) {
@@ -45,6 +46,9 @@ func (b BigQueryDriver) Open(uri string) (driver.Conn, error) {
 	}
 	if config.disableAuth {
 		opts = append(opts, option.WithoutAuthentication())
+	}
+	if config.credentialsFile != "" {
+		opts = append(opts, option.WithCredentialsFile(config.credentialsFile))
 	}
 
 	client, err := bigquery.NewClient(ctx, config.projectID, opts...)
@@ -85,11 +89,12 @@ func configFromUri(uri string) (*bigQueryConfig, error) {
 	}
 
 	config := &bigQueryConfig{
-		projectID:   u.Hostname(),
-		dataSet:     datasetName,
-		scopes:      getScopes(u.Query()),
-		endpoint:    u.Query().Get("endpoint"),
-		disableAuth: u.Query().Get("disable_auth") == "true",
+		projectID:       u.Hostname(),
+		dataSet:         datasetName,
+		scopes:          getScopes(u.Query()),
+		endpoint:        u.Query().Get("endpoint"),
+		disableAuth:     u.Query().Get("disable_auth") == "true",
+		credentialsFile: u.Query().Get("credentials_file"),
 	}
 
 	if len(fields) == 2 {


### PR DESCRIPTION
## Summary

Adds a `credentials_file` query parameter to the BigQuery DSN, allowing callers to specify a GCP service account key file per connection. When set, the driver passes `option.WithCredentialsFile` to the BigQuery client, overriding the default ADC credentials.

This enables use cases where different connections need different SA keys — e.g., read-only vs read-write BigQuery access from the same process.

### Usage

```
bigquery://project-id/location/dataset?credentials_file=/path/to/sa-key.json
```

When `credentials_file` is omitted, the driver falls back to ADC (existing behavior, no change).

## Context

Needed by `scaledata/sdmain` PR [#165436](https://github.com/scaledata/sdmain/pull/165436) — OLAP write query support with separate read/write SA credentials.