### PR TITLE
Set client.Location from DSN location segment

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -74,6 +74,14 @@ func (b BigQueryDriver) Open(uri string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+	// If the DSN included a location segment
+	// (bigquery://project/location/dataset), use it as the
+	// client's default location. This routes job submissions
+	// (including INFORMATION_SCHEMA queries) to the correct
+	// region instead of the BQ Go client's US default.
+	if config.location != "" {
+		client.Location = config.location
+	}
 
 	return &bigQueryConnection{
 		ctx:    ctx,


### PR DESCRIPTION
## Summary

The driver already parses `bigquery://project/location/dataset` into
`config.location` (`driver.go:134`), but never reads it back when
creating the BigQuery client. As a result, the underlying
`bigquery.Client` is constructed without `Location` set, and job
submissions default to US even when callers explicitly include a
location segment in their DSN.

This breaks region-sensitive queries on non-US datasets — most
notably `INFORMATION_SCHEMA.TABLES` lookups, where the BigQuery
backend can't auto-resolve location from the default dataset and
falls back to US, returning `Dataset not found in location US`.

## Fix

Copy `config.location` to `client.Location` after `NewClient(...)`
when non-empty:

```go
client, err := bigquery.NewClient(ctx, config.projectID, opts...)
if err != nil {
    return nil, err
}
if config.location != "" {
    client.Location = config.location
}
```

With this, callers using the documented 2-segment DSN form get their
jobs routed to the correct region.

## Backward compatibility

1-segment DSNs (`bigquery://project/dataset`, no location segment)
are unaffected — `config.location` is empty, the new branch is
skipped, and `client.Location` stays empty. Existing callers see no
behavior change.

## Tests

Existing `TestConfigFromUri` cases already cover the parsing side
(e.g. `bigquery://my-project/US/my-dataset` → `config.location = "US"`),
so the parsing-to-client wiring is now end-to-end correct.

## Downstream consumer

Tracking the consumer-side change (uses 2-segment DSN form) in
[scaledata/sdmain — plan PR forthcoming].
